### PR TITLE
ci(dependabot): change npm path to /action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
 
   - package-ecosystem: npm
     open-pull-requests-limit: 10
-    directory: /
+    directory: /action
     schedule:
       interval: daily
 


### PR DESCRIPTION
This should allow dependabot to update the npm packages. Then, hopefully this action can be upgraded to use commitlint 11.